### PR TITLE
Add mirego/optional-box-shadow-values rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,42 @@ This rule makes sure that when we use the `rgba` function, we use the one Sass p
 }
 ```
 
+#### `box-shadow-optional-values`
+
+This rule makes sure that we don’t specify useless default values in `box-shadow` properties.
+
+```css
+/* Good */
+#one {
+  box-shadow: 10px 10px 0 2px #f00;
+}
+
+#two {
+  box-shadow: 10px 10px 2px #f00;
+}
+
+#three {
+  box-shadow: 10px 10px #f00;
+}
+
+#four {
+  box-shadow: inset 10px 10px 4px #f00;
+}
+
+/* Bad */
+#five {
+  box-shadow: 10px 10px 0 0 #f00;
+}
+
+#six {
+  box-shadow: 10px 10px 4px 0 #f00;
+}
+
+#seven {
+  box-shadow: inset 10px 10px 4px 0 #f00;
+}
+```
+
 ## License
 
 `stylelint-mirego` is © 2017 [Mirego](http://www.mirego.com) and may be freely distributed under the [New BSD license](http://opensource.org/licenses/BSD-3-Clause).  See the [`LICENSE.md`](https://github.com/mirego/stylelint-mirego/blob/master/LICENSE.md) file.

--- a/rules/optional-box-shadow-values.js
+++ b/rules/optional-box-shadow-values.js
@@ -1,0 +1,25 @@
+'use strict';
+
+// Vendor
+const {createPlugin, utils} = require('stylelint');
+
+// Configuration
+const ruleName = 'mirego/optional-box-shadow-values';
+const messages = utils.ruleMessages(ruleName, {
+  default: () => {
+    return 'You should not specify `0` as box-shadow’s `blur-radius` or `spread-radius` value because it’s `0` by default.';
+  }
+});
+
+module.exports = createPlugin(ruleName, () => (cssRoot, result) => {
+  cssRoot.walkDecls('box-shadow', (node) => {
+    const {value} = node;
+    if (!value.match(/(inset\s+)?\w+\s+\w+\s+(0\s*$|0\s+\D|0\s+0|^0\w+\s+0)/)) return;
+
+    const message = messages.default();
+
+    utils.report({ruleName, result, node, message});
+  });
+});
+
+module.exports.messages = messages;

--- a/test/index.js
+++ b/test/index.js
@@ -61,3 +61,52 @@ testRule(preferSassRgbaFunction.rule, {
     }
   ]
 });
+
+const optionalBoxShadowValues = require('../rules/optional-box-shadow-values');
+
+testRule(optionalBoxShadowValues.rule, {
+  ruleName: optionalBoxShadowValues.ruleName,
+  skipBasicChecks: true,
+
+  accept: [
+    {
+      code: 'a { box-shadow: 10px 10px 4px #f00; }'
+    },
+    {
+      code: 'a { box-shadow: 10px 10px 4px 2px #f00; }'
+    },
+    {
+      code: 'a { box-shadow: 10px 10px 0 2px #f00; }'
+    },
+    {
+      code: 'a { box-shadow: inset 10px 10px 0 2px #f00; }'
+    },
+    {
+      code: 'a { box-shadow: inset 10px 10px 5px 2px #f00; }'
+    },
+    {
+      code: 'a { box-shadow: inset 10px 10px 5px #f00; }'
+    },
+    {
+      code: 'a { box-shadow: inherit; }'
+    }
+  ],
+  reject: [
+    {
+      code: 'a { box-shadow: 10px 10px 4px 0 #f00; }',
+      message: optionalBoxShadowValues.messages.default()
+    },
+    {
+      code: 'a { box-shadow: inset 10px 10px 10px 0 #f00; }',
+      message: optionalBoxShadowValues.messages.default()
+    },
+    {
+      code: 'a { box-shadow: inset 10px 10px 0 0 #f00; }',
+      message: optionalBoxShadowValues.messages.default()
+    },
+    {
+      code: 'a { box-shadow: 10px 10px 4px 0; }',
+      message: optionalBoxShadowValues.messages.default()
+    }
+  ]
+});


### PR DESCRIPTION
Shoutout to @pboutin for the awesome _regexp_! 🎉 

```css
/* Good */
#one {
  box-shadow: 10px 10px 2px #f00;
}

/* Bad */
#two {
  box-shadow: 10px 10px 2px 0 #f00;
}
```