### PR TITLE
Handle multiple rgba functions in single property value

### DIFF
--- a/rules/prefer-sass-rgba-function.js
+++ b/rules/prefer-sass-rgba-function.js
@@ -14,7 +14,7 @@ const messages = utils.ruleMessages(ruleName, {
 module.exports = createPlugin(ruleName, () => (cssRoot, result) => {
   cssRoot.walkDecls((node) => {
     const {value} = node;
-    if (!value.match(/rgba\([^,]+,[^,]+,[^,]+,[^,]+\)/)) return;
+    if (!value.match(/rgba\([^,)]+,[^,)]+,[^,)]+,[^,)]+\)/)) return;
 
     const message = messages.default();
 

--- a/test/index.js
+++ b/test/index.js
@@ -48,6 +48,9 @@ testRule(preferSassRgbaFunction.rule, {
     },
     {
       code: 'a { background: rgba(blue, $alpha); }'
+    },
+    {
+      code: 'a { background: linear-gradient(to bottom, rgba(#004883, 0.8), rgba(#002c50, 0.8)); }'
     }
   ],
   reject: [
@@ -57,6 +60,14 @@ testRule(preferSassRgbaFunction.rule, {
     },
     {
       code: 'a { background: rgba(0, 0, 0, 0.9); }',
+      message: preferSassRgbaFunction.messages.default()
+    },
+    {
+      code: 'a { background: linear-gradient(to bottom, rgba(255, 0, 255, 0.8), rgba(#002c50, 0.8)); }',
+      message: preferSassRgbaFunction.messages.default()
+    },
+    {
+      code: 'a { background: linear-gradient(to bottom, rgba(red, 0.8), rgba(0, 0, 255, 0.8)); }',
       message: preferSassRgbaFunction.messages.default()
     }
   ]


### PR DESCRIPTION
I added three new test cases and made sure they pass. In a nutshell, values like:

```
linear-gradient(to bottom, rgba(#ff0000, 0.8), rgba(#00ff00, 0.8))
```

were not accepted when they should have been.