### PR TITLE
Update peer stylelint version

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
     "stylelint-test-rule-tape": "^0.2.0"
   },
   "peerDependencies": {
-    "stylelint": "^8.0.0"
+    "stylelint": ">= 8.0.0"
   }
 }


### PR DESCRIPTION
I have an "unmet peerDependency" warning in my project because I use stylelint 9.1.1. Since this has no consequence on this codebase, I think we should "support" future versions.