### PR TITLE
Prevent box-shadow rule to fail on "inset 0 0 0 something"

### DIFF
--- a/rules/box-shadow-optional-values.js
+++ b/rules/box-shadow-optional-values.js
@@ -14,7 +14,7 @@ const messages = utils.ruleMessages(ruleName, {
 module.exports = createPlugin(ruleName, () => (cssRoot, result) => {
   cssRoot.walkDecls('box-shadow', (node) => {
     const {value} = node;
-    if (!value.match(/(inset\s+)?\w+\s+\w+\s+(0\s*$|0\s+\D|0\s+0|^0\w+\s+0)/)) return;
+    if (!value.match(/(inset\s+)?\d\w*\s+\d\w*\s+(0\s*$|0\s+\D|0\s+0|^0\w+\s+0)/)) return;
 
     const message = messages.default();
 

--- a/test/index.js
+++ b/test/index.js
@@ -99,6 +99,9 @@ testRule(boxShadowOptionalValues.rule, {
       code: 'a { box-shadow: inset 10px 10px 5px #f00; }'
     },
     {
+      code: 'a { box-shadow: inset 0 0 0 30px red; }'
+    },
+    {
       code: 'a { box-shadow: inherit; }'
     }
   ],


### PR DESCRIPTION
The first offset param matcher `\w+` wrongly matched `inset`, which
made the regex to mismatch the following params.