### PR TITLE
Introduce a new rule to prevent BEM selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,24 @@ This rule makes sure that we don’t specify useless default values in `box-shad
 }
 ```
 
+### `no-bem-selector`
+
+This rule makes sure that we don't use the BEM notation for selectors.
+
+```css
+/* Good */
+.button { }
+
+.button.active { }
+
+.button .label { }
+
+/* Bad */
+.button--active { }
+
+.button__label { }
+```
+
 ## License
 
 `stylelint-mirego` is © 2017 [Mirego](http://www.mirego.com) and may be freely distributed under the [New BSD license](http://opensource.org/licenses/BSD-3-Clause).  See the [`LICENSE.md`](https://github.com/mirego/stylelint-mirego/blob/master/LICENSE.md) file.

--- a/index.js
+++ b/index.js
@@ -3,5 +3,6 @@
 module.exports = [
   require('./rules/single-decimal-line-height'),
   require('./rules/prefer-sass-rgba-function'),
-  require('./rules/box-shadow-optional-values')
+  require('./rules/box-shadow-optional-values'),
+  require('./rules/no-bem-selector')
 ];

--- a/rules/no-bem-selector.js
+++ b/rules/no-bem-selector.js
@@ -1,0 +1,26 @@
+'use strict';
+
+// Vendor
+const {createPlugin, utils} = require('stylelint');
+
+// Configuration
+const ruleName = 'mirego/no-bem-selector';
+const messages = utils.ruleMessages(ruleName, {
+  default: () => {
+    return 'BEM selector should not be used in projects with local CSS.';
+  }
+});
+
+// Constants
+const BEM_REGEX = /(\-\-|\_\_)/;
+
+module.exports = createPlugin(ruleName, () => (cssRoot, result) => {
+  cssRoot.walkRules(BEM_REGEX, (rule) => {
+    const message = messages.default();
+    const line = rule.source.start.line;
+
+    utils.report({ruleName, result, message, line});
+  });
+});
+
+module.exports.messages = messages;

--- a/rules/no-bem-selector.js
+++ b/rules/no-bem-selector.js
@@ -12,7 +12,7 @@ const messages = utils.ruleMessages(ruleName, {
 });
 
 // Constants
-const BEM_REGEX = /(\-\-|\_\_)/;
+const BEM_REGEX = /\w(\-\-|\_\_)\w/;
 
 module.exports = createPlugin(ruleName, () => (cssRoot, result) => {
   cssRoot.walkRules(BEM_REGEX, (rule) => {

--- a/test/index.js
+++ b/test/index.js
@@ -140,6 +140,12 @@ testRule(noBemSelector.rule, {
     },
     {
       code: '.button.modifier { color: hotpink; }'
+    },
+    {
+      code: 'element { --main-background-color: red; }'
+    },
+    {
+      code: 'element { background: var(--main-background-color); }'
     }
   ],
   reject: [

--- a/test/index.js
+++ b/test/index.js
@@ -124,3 +124,30 @@ testRule(boxShadowOptionalValues.rule, {
     }
   ]
 });
+
+const noBemSelector = require('../rules/no-bem-selector');
+
+testRule(noBemSelector.rule, {
+  ruleName: noBemSelector.ruleName,
+  skipBasicChecks: true,
+
+  accept: [
+    {
+      code: '.button { color: hotpink; }'
+    },
+    {
+      code: '.button-something { color: hotpink; }'
+    },
+    {
+      code: '.button.modifier { color: hotpink; }'
+    }
+  ],
+  reject: [
+    {
+      code: '.button__children { color: hotpink; }'
+    },
+    {
+      code: '.button.button--modifier { color: hotpink; }'
+    }
+  ]
+});


### PR DESCRIPTION
The BEM notation is often replaced with other technologies, such as
 _css modules_. It would be nice to have a rule available
to enforce this transition.